### PR TITLE
checkout

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [version-increment]
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18.x

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,7 +1,6 @@
 name: Automat JS Tools CD
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "automat-js-tools",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "automat-js-tools",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "ISC",
       "dependencies": {
         "winston": "^3.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@automat/automat-js-tools",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Publishes to our shiny new [NPM repository](https://us-central1-npm.pkg.dev/lasso-cloud-378118/automat-npm) hosted in Google Artifact. We can now use `npm i @automat/automat-js-tools@latest`
- This gives us version targeting. And it's good to know how to deploy to GCloud Artifacts.